### PR TITLE
Fix Redis cache deletion key

### DIFF
--- a/utils/redis_utils.py
+++ b/utils/redis_utils.py
@@ -50,7 +50,7 @@ def set_generic_cache(path: str, data: dict, ttl: int = 3600):  # Default 1 hour
 def delete_generic_cache(path: str):
     key = base64.b64encode(f'{path}'.encode('utf-8'))
     key = key.decode('utf-8')
-    r.delete(f'josancamon:rayban-meta-glasses-api{key}')
+    r.delete(f'josancamon:rayban-meta-glasses-api:{key}')
 
 # ------------ Reminder Management ------------
 @try_catch_decorator


### PR DESCRIPTION
## Summary
- fix incorrect key format when deleting generic cache entries

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684421a3fd5c8323b7a2cb7e459a1697